### PR TITLE
Enable SUPPORTS_ROOT_NS to allow managing root NS records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.0.3 - 2022-??-?? - Support the root
+
+* Enable SUPPORTS_ROOT_NS for management of root NS records. Requires
+  octodns>=0.9.16.
+
 ## v0.0.2 - 2022-02-02 - pycountry-convert install_requires
 
 * install_requires includes pycountry-convert as it's a runtime requirement

--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ providers:
 
 All octoDNS record types are supported.
 
+#### Root NS Records
+
+Ns1Provider supports full root NS record management.
+
 #### Dynamic
 
 Ns1Provider supports dynamic records.

--- a/octodns_ns1/__init__.py
+++ b/octodns_ns1/__init__.py
@@ -275,6 +275,7 @@ class Ns1Provider(BaseProvider):
     SUPPORTS_DYNAMIC = True
     SUPPORTS_POOL_VALUE_STATUS = True
     SUPPORTS_MULTIVALUE_PTR = True
+    SUPPORTS_ROOT_NS = True
     SUPPORTS = set(('A', 'AAAA', 'ALIAS', 'CAA', 'CNAME', 'MX', 'NAPTR',
                     'NS', 'PTR', 'SPF', 'SRV', 'TXT', 'URLFWD'))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ idna==3.3
 iniconfig==1.1.1
 natsort==8.1.0
 ns1-python==0.17.1
-octodns==0.9.14
 packaging==21.3
 pluggy==1.0.0
 pprintpp==0.4.0
@@ -27,3 +26,5 @@ six==1.16.0
 toml==0.10.2
 tomli==2.0.0
 urllib3==1.26.8
+
+-e git+https://git@github.com/github/octodns.git@root-ns-support#egg=octodns

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ idna==3.3
 iniconfig==1.1.1
 natsort==8.1.0
 ns1-python==0.17.1
+octodns==0.9.16
 packaging==21.3
 pluggy==1.0.0
 pprintpp==0.4.0
@@ -26,5 +27,3 @@ six==1.16.0
 toml==0.10.2
 tomli==2.0.0
 urllib3==1.26.8
-
--e git+https://git@github.com/github/octodns.git@root-ns-support#egg=octodns

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         ),
     },
     install_requires=(
-        'octodns>=0.9.14',
+        'octodns>=0.9.16',
         'ns1_python>=0.17.1',
         'pycountry-convert>=0.7.2',
     ),

--- a/tests/test_provider_ns1.py
+++ b/tests/test_provider_ns1.py
@@ -335,8 +335,7 @@ class TestNs1Provider(TestCase):
             desired.add_record(r)
 
         plan = provider.plan(desired)
-        # everything except the root NS
-        expected_n = len(self.expected) - 1
+        expected_n = len(self.expected)
         self.assertEqual(expected_n, len(plan.changes))
         self.assertTrue(plan.exists)
 
@@ -389,6 +388,9 @@ class TestNs1Provider(TestCase):
             call('unit.tests', 'unit.tests', 'MX', answers=[
                 (10, 'mx1.unit.tests.'), (20, 'mx2.unit.tests.')
             ], ttl=35),
+            call('unit.tests', 'unit.tests', 'NS', answers=[
+                'ns1.unit.tests.', 'ns2.unit.tests.',
+            ], ttl=37),
             call('unit.tests', '1.2.3.4.unit.tests', 'PTR', answers=[
                 'one.one.one.one.', 'two.two.two.two.',
             ], ttl=42),


### PR DESCRIPTION


/cc https://github.com/octodns/octodns/pull/876 which adds the underlying support 
/cc https://github.com/octodns/octodns/issues/38 which tracks the broader functionality request