### PR TITLE
add missing required module in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
         'octodns>=0.9.16',
         'ns1_python>=0.17.1',
         'pycountry-convert>=0.7.2',
+        'requests>=2.27.1',
     ),
     license='MIT',
     long_description=long_description,


### PR DESCRIPTION
`requirements.txt` contains the `requests` module as a dependency.  but it is missing in the setup.py. 
If you run octodns for NS1 provider without requests it fails when it needs to create a new zone in NS1.

https://github.com/octodns/octodns-ns1/issues/14