### PR TITLE
Don't fail on unsupported tier > 1 records in populate

### DIFF
--- a/octodns_ns1/__init__.py
+++ b/octodns_ns1/__init__.py
@@ -874,7 +874,7 @@ class Ns1Provider(BaseProvider):
                                       'SRV']:
                     record['short_answers'] = [
                         _ensure_endswith_dot(a)
-                        for a in record['short_answers']
+                        for a in record.get('short_answers', [])
                     ]
 
                 if record.get('tier', 1) > 1:


### PR DESCRIPTION
Not all records have `short_answers` so we need to avoid the `KeyError` on those that don't. This also adds a test case from the problematic record provided in https://github.com/octodns/octodns-ns1/issues/17 and fixes some ~bugs in the existing test code where answers weren't what they were expected to be (likely copy-n-paste errors.)

/cc https://github.com/octodns/octodns-ns1/issues/17 @flz