### PR TITLE
Bump ns1-python version to 0.18.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ fqdn==1.5.1
 idna==3.3
 iniconfig==1.1.1
 natsort==8.1.0
-ns1-python==0.17.4
+ns1-python==0.18.0
 octodns==0.9.17
 packaging==21.3
 pluggy==1.0.0


### PR DESCRIPTION
Upstream had accepted my PR to support python 3.10 in https://github.com/ns1/ns1-python