### PR TITLE
v0.0.3 version bump and CHANGELOG update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.0.3 - 2023-??-?? - Support the root
+## v0.0.3 - 2023-01-24 - Support the root
 
 * Enable SUPPORTS_ROOT_NS for management of root NS records. Requires
   octodns>=0.9.16.

--- a/octodns_ns1/__init__.py
+++ b/octodns_ns1/__init__.py
@@ -17,7 +17,7 @@ from octodns.provider.base import BaseProvider
 from octodns.record import Record, Update
 
 
-__VERSION__ = '0.0.2'
+__VERSION__ = '0.0.3'
 
 
 def _ensure_endswith_dot(string):


### PR DESCRIPTION
## v0.0.3 - 2023-01-24 - Support the root

* Enable SUPPORTS_ROOT_NS for management of root NS records. Requires
  octodns>=0.9.16.
* Configurable http version for dynamic HTTPS monitors, to enable HTTP/1.1 support