### PR TITLE
Revert order of self._COUNTRY_FILTER and self._REGION_FILTER

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.0.4 - 2023-??-?? - ???
+
+* Dynamic records filter chain ordering reworked to place country filters before
+  regions, see https://github.com/octodns/octodns-ns1/pull/37 for
+  details/discussion.
+
 ## v0.0.3 - 2023-01-24 - Support the root
 
 * Enable SUPPORTS_ROOT_NS for management of root NS records. Requires

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
   details/discussion.
 * AS implemented as a list of countries rather than the ASIAPAC region which
   didn't match as the AS list of countries in the first place
+* AS, NA, and OC source their list of countries from octodns.record.geo_data
+  rather than manually duplicating the information here.
 * Add TL to the list of special case countries so that it can be individually
   targeted
 * Fix for rule ordering when there's > 10 rules

--- a/octodns_ns1/__init__.py
+++ b/octodns_ns1/__init__.py
@@ -379,8 +379,8 @@ class Ns1Provider(BaseProvider):
     def _FILTER_CHAIN_WITH_REGION_AND_COUNTRY(self):
         return [
             self._UP_FILTER,
-            self._REGION_FILTER,
             self._COUNTRY_FILTER,
+            self._REGION_FILTER,
             self._SELECT_FIRST_REGION_FILTER,
             self._PRIORITY_FILTER,
             self._WEIGHTED_SHUFFLE_FILTER,


### PR DESCRIPTION
Make synthetic ocean region work by moving the more specific rules to the top.

Fixes #36