### PR TITLE
_monitor_is_match needs to use expected for nested dict `config` too

### DIFF
--- a/octodns_ns1/__init__.py
+++ b/octodns_ns1/__init__.py
@@ -1197,7 +1197,14 @@ class Ns1Provider(BaseProvider):
         # Make sure what we have matches what's in expected exactly. Anything
         # else in have will be ignored.
         for k, v in expected.items():
-            if have.get(k, '--missing--') != v:
+            if k == 'config':
+                # config is a nested dict and we need to only consider keys in
+                # expected for it as well
+                have_config = have.get(k, {})
+                for k, v in v.items():
+                    if have_config.get(k, '--missing--') != v:
+                        return False
+            elif have.get(k, '--missing--') != v:
                 return False
 
         return True

--- a/tests/test_provider_ns1.py
+++ b/tests/test_provider_ns1.py
@@ -1137,6 +1137,14 @@ class TestNs1ProviderDynamic(TestCase):
             )
         )
 
+        # extra stuff in the config section doesn't cause problems
+        self.assertTrue(
+            provider._monitor_is_match(
+                {'config': {'key': 42, 'value': 43}},
+                {'config': {'key': 42, 'value': 43, 'other': 44}},
+            )
+        )
+
     @patch('octodns_ns1.Ns1Provider._feed_create')
     @patch('octodns_ns1.Ns1Client.monitors_update')
     @patch('octodns_ns1.Ns1Provider._monitor_create')


### PR DESCRIPTION
Cribbed from https://github.com/octodns/octodns-ns1/issues/35#issuecomment-1487065395

The false/persistent update is coming from `_extra_changes` 

```console
2023-03-28T07:55:32  [4644720128] INFO  Ns1Provider[ns1] _extra_changes: monitor mis-match for a.exxampled.com - A - 1.1.1.1
```

Which is triggered when `_monitor_is_match` returns `False`:

https://github.com/octodns/octodns-ns1/blob/bc542be4ac73d3914adcfd5d1ce2f56ff484e119/octodns_ns1/__init__.py#L1196-L1203

Printing out the two

```python
{'expected': {'active': True,
              'config': {'connect_timeout': 2000,
                         'host': '1.1.1.1',
                         'port': 443,
                         'response_timeout': 10000,
                         'send': 'GET /_dns HTTP/1.0\\r\\nHost: '
                                 'a.exxampled.com\\r\\nUser-agent: '
                                 'NS1\\r\\n\\r\\n',
                         'ssl': True},
              'frequency': 60,
              'job_type': 'tcp',
              'name': 'a.exxampled.com - A - 1.1.1.1',
              'notes': 'host:a.exxampled.com type:A',
              'policy': 'quorum',
              'rapid_recheck': False,
              'region_scope': 'fixed',
              'regions': ['lga'],
              'rules': [{'comparison': 'contains',
                         'key': 'output',
                         'value': '200 OK'}]},
 'have': {'active': True,
          'config': {'connect_timeout': 2000,
                     'host': '1.1.1.1',
                     'ipv6': False,
                     'port': 443,
                     'response_timeout': 10000,
                     'send': 'GET /_dns HTTP/1.0\\r\\nHost: '
                             'a.exxampled.com\\r\\nUser-agent: NS1\\r\\n\\r\\n',
                     'ssl': True,
                     'tls_add_verify': False},
          'frequency': 60,
          'id': '6422ff1c65f383007cace839',
          'job_type': 'tcp',
          'mute': False,
          'name': 'a.exxampled.com - A - 1.1.1.1',
          'notes': 'host:a.exxampled.com type:A',
          'notify_delay': 0,
          'notify_failback': True,
          'notify_list': '62f29339f6491b0095148771',
          'notify_regional': False,
          'notify_repeat': 0,
          'policy': 'quorum',
          'rapid_recheck': False,
          'region_scope': 'fixed',
          'regions': ['lga'],
          'rules': [{'comparison': 'contains',
                     'key': 'output',
                     'value': '200 OK'}],
          'status': {'global': {'fail_set': ['lga'],
                                'since': 1680015196,
                                'status': 'down'},
                     'lga': {'fail_set': ['Failure for Rule: output contains '
                                          '200 OK'],
                             'since': 1680015196,
                             'status': 'down'}}}}
```

```python
{'have.get': {'connect_timeout': 2000,
              'host': '1.1.1.1',
              'ipv6': False,
              'port': 443,
              'response_timeout': 10000,
              'send': 'GET /_dns HTTP/1.0\\r\\nHost: '
                      'a.exxampled.com\\r\\nUser-agent: NS1\\r\\n\\r\\n',
              'ssl': True,
              'tls_add_verify': False},
 'k': 'config',
 'mismatch': True,
 'v': {'connect_timeout': 2000,
       'host': '1.1.1.1',
       'port': 443,
       'response_timeout': 10000,
       'send': 'GET /_dns HTTP/1.0\\r\\nHost: a.exxampled.com\\r\\nUser-agent: '
               'NS1\\r\\n\\r\\n',
       'ssl': True}}
```


Looks like they've added a new keys to the `config` section: `tls_add_verify` and  `ipv6` and the current method of comparison sees that as a diff. 

Working on a PR/solution now.

/cc Found when trying to reproduce https://github.com/octodns/octodns-ns1/issues/35 @istr 