### PR TITLE
AS as a country list rather than ASIAPAC region, fix TL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Add TL to the list of special case countries so that it can be individually
   targeted
 * Fix for rule ordering when there's > 10 rules
+* Fixed persistent change issue with dynamic records after the API started
+  returning new fields under `config`
 
 ## v0.0.3 - 2023-01-24 - Support the root
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v0.0.4 - 2023-??-?? - ???
+
+* AS implemented as a list of countries rather than the ASIAPAC region which
+  didn't match as the AS list of countries in the first place
+* Add TL to the list of special case countries so that it can be individually
+  targeted
+
 ## v0.0.3 - 2023-01-24 - Support the root
 
 * Enable SUPPORTS_ROOT_NS for management of root NS records. Requires

--- a/octodns_ns1/__init__.py
+++ b/octodns_ns1/__init__.py
@@ -402,13 +402,13 @@ class Ns1Provider(BaseProvider):
     }
     _CONTINENT_TO_REGIONS = {
         'AF': ('AFRICA',),
-        'AS': ('ASIAPAC',),
         'EU': ('EUROPE',),
         'SA': ('SOUTH-AMERICA',),
     }
 
     # Necessary for handling unsupported continents in _CONTINENT_TO_REGIONS
     _CONTINENT_TO_LIST_OF_COUNTRIES = {
+        'AS': set(geo_data['AS'].keys()),
         'OC': set(geo_data['OC'].keys()),
         'NA': set(geo_data['NA'].keys()),
     }
@@ -616,10 +616,12 @@ class Ns1Provider(BaseProvider):
             # country_alpha2_to_continent_code fails for Pitcairn ('PN'),
             # United States Minor Outlying Islands ('UM') and
             # Sint Maarten ('SX')
-            if country in ('PN', 'UM'):
-                con = 'OC'
+            if country == 'TL':
+                con = 'AS'
             elif country == 'SX':
                 con = 'NA'
+            elif country in ('PN', 'UM'):
+                con = 'OC'
             else:
                 con = country_alpha2_to_continent_code(country)
 

--- a/tests/test_provider_ns1.py
+++ b/tests/test_provider_ns1.py
@@ -1368,7 +1368,7 @@ class TestNs1ProviderDynamic(TestCase):
         rule0 = record.data['dynamic']['rules'][0]
         rule1 = record.data['dynamic']['rules'][1]
         rule0['geos'] = ['AF', 'EU']
-        rule1['geos'] = ['AS']
+        rule1['geos'] = ['SA']
         ret, monitor_ids = provider._params_for_A(record)
         self.assertEqual(10, len(ret['answers']))
         self.assertEqual(ret['filters'], provider._FILTER_CHAIN_WITH_REGION)
@@ -1376,7 +1376,10 @@ class TestNs1ProviderDynamic(TestCase):
             {
                 'iad__catchall': {'meta': {'note': 'rule-order:2'}},
                 'iad__georegion': {
-                    'meta': {'georegion': ['ASIAPAC'], 'note': 'rule-order:1'}
+                    'meta': {
+                        'georegion': ['SOUTH-AMERICA'],
+                        'note': 'rule-order:1',
+                    }
                 },
                 'lhr__georegion': {
                     'meta': {
@@ -1471,7 +1474,7 @@ class TestNs1ProviderDynamic(TestCase):
         rule0 = record.data['dynamic']['rules'][0]
         rule1 = record.data['dynamic']['rules'][1]
         rule0['geos'] = ['AF', 'EU', 'NA-US-CA']
-        rule1['geos'] = ['AS', 'AS-IN']
+        rule1['geos'] = ['SA', 'AS-IN']
         ret, _ = provider._params_for_A(record)
 
         self.assertEqual(17, len(ret['answers']))
@@ -1536,7 +1539,10 @@ class TestNs1ProviderDynamic(TestCase):
                     'meta': {'country': ['IN'], 'note': 'rule-order:1'}
                 },
                 'iad__georegion': {
-                    'meta': {'georegion': ['ASIAPAC'], 'note': 'rule-order:1'}
+                    'meta': {
+                        'georegion': ['SOUTH-AMERICA'],
+                        'note': 'rule-order:1',
+                    }
                 },
                 'lhr__country': {
                     'meta': {
@@ -2845,3 +2851,20 @@ class TestNs1Client(TestCase):
             client._records_cache,
         )
         self.assertEqual({}, client._zones_cache)
+
+    def test_parse_rule_geos_special_cases(self):
+        provider = Ns1Provider('test', 'api-key')
+
+        notes = {}
+
+        meta = {'country': ('TL',)}
+        geos = provider._parse_rule_geos(meta, notes)
+        self.assertEqual({'AS-TL'}, geos)
+
+        meta = {'country': ('SX',)}
+        geos = provider._parse_rule_geos(meta, notes)
+        self.assertEqual({'NA-SX'}, geos)
+
+        meta = {'country': ('PN', 'UM')}
+        geos = provider._parse_rule_geos(meta, notes)
+        self.assertEqual({'OC-PN', 'OC-UM'}, geos)


### PR DESCRIPTION
- country_alpha2_to_continent_code didn't support TL, add it to the manual list
- rework some tests that were using AS as a region to use SA instead
- explicitly test _parse_rule_geos special_cases

/cc https://github.com/octodns/octodns-ns1/pull/40 which this builds on
/cc https://github.com/octodns/octodns-ns1/issues/38 which lead to this change
/cc @viranch @istr 