### PR TITLE
Fix for rule ordering when there's > 10 rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.0.4 - 2023-??-?? - ???
+
+* Fix for rule ordering when there's > 10 rules
+
 ## v0.0.3 - 2023-01-24 - Support the root
 
 * Enable SUPPORTS_ROOT_NS for management of root NS records. Requires

--- a/octodns_ns1/__init__.py
+++ b/octodns_ns1/__init__.py
@@ -550,9 +550,13 @@ class Ns1Provider(BaseProvider):
             for piece in note.split(' '):
                 try:
                     k, v = piece.split(':', 1)
-                    data[k] = v if v != '' else None
+                except ValueError:
+                    continue
+                try:
+                    v = int(v)
                 except ValueError:
                     pass
+                data[k] = v if v != '' else None
         return data
 
     def _data_for_geo_A(self, _type, record):

--- a/tests/test_provider_ns1.py
+++ b/tests/test_provider_ns1.py
@@ -848,9 +848,25 @@ class TestNs1ProviderDynamic(TestCase):
         self.assertEqual({}, provider._parse_notes('blah-blah-blah'))
 
         # Round tripping
-        data = {'key': 'value', 'priority': '1'}
+        data = {'key': 'value', 'priority': 1}
         notes = provider._encode_notes(data)
         self.assertEqual(data, provider._parse_notes(notes))
+
+        # integers come out as int
+        self.assertEqual(
+            {'rule-order': 1}, provider._parse_notes('rule-order:1')
+        )
+
+        # floats come out as strings (not currently used so not parsed)
+        self.assertEqual(
+            {'rule-order': '1.2'}, provider._parse_notes('rule-order:1.2')
+        )
+
+        # strings that start with integers are still strings
+        self.assertEqual(
+            {'rule-order': '1-thing'},
+            provider._parse_notes('rule-order:1-thing'),
+        )
 
     def test_monitors_for(self):
         provider = Ns1Provider('test', 'api-key')
@@ -1804,12 +1820,12 @@ class TestNs1ProviderDynamic(TestCase):
                     },
                     'rules': [
                         {
-                            '_order': '1',
+                            '_order': 1,
                             'geos': ['AF', 'NA-CA-NL', 'NA-MX', 'NA-US-OR'],
                             'pool': 'lhr',
                         },
-                        {'_order': '2', 'geos': ['AF-ZW'], 'pool': 'iad'},
-                        {'_order': '3', 'pool': 'iad'},
+                        {'_order': 2, 'geos': ['AF-ZW'], 'pool': 'iad'},
+                        {'_order': 3, 'pool': 'iad'},
                     ],
                 },
                 'ttl': 42,
@@ -1980,16 +1996,16 @@ class TestNs1ProviderDynamic(TestCase):
                     },
                     'rules': [
                         {
-                            '_order': '1',
+                            '_order': 1,
                             'geos': ['NA-CA', 'NA-US-OR'],
                             'pool': 'one',
                         },
                         {
-                            '_order': '2',
+                            '_order': 2,
                             'geos': ['NA-CA', 'NA-US-OR'],
                             'pool': 'four',
                         },
-                        {'_order': '3', 'pool': 'iad'},
+                        {'_order': 3, 'pool': 'iad'},
                     ],
                 },
                 'ttl': 42,
@@ -2049,7 +2065,7 @@ class TestNs1ProviderDynamic(TestCase):
                             ],
                         }
                     },
-                    'rules': [{'_order': '1', 'pool': 'iad'}],
+                    'rules': [{'_order': 1, 'pool': 'iad'}],
                 },
                 'ttl': 43,
                 'type': 'CNAME',


### PR DESCRIPTION
Notes was returning "10" (str) which doesn't sort numerical

/cc Fixes https://github.com/octodns/octodns-ns1/issues/35 @istr 