### PR TITLE
v0.0.4 version bump & changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.0.4 - 2023-??-?? - ???
+## v0.0.4 - 2023-03-31 - More (accurately) Dynamic
 
 * Dynamic records filter chain ordering reworked to place country filters before
   regions, see https://github.com/octodns/octodns-ns1/pull/37 for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.0.4 - 2023-03-31 - More (accurately) Dynamic
+## v0.0.4 - 2023-04-06 - More (accurately) Dynamic
 
 * Dynamic records filter chain ordering reworked to place country filters before
   regions, see https://github.com/octodns/octodns-ns1/pull/37 for
@@ -12,6 +12,8 @@
 * Fix for rule ordering when there's > 10 rules
 * Fixed persistent change issue with dynamic records after the API started
   returning new fields under `config`
+* Fixed persistent change bug when a dynamic record is updated to be a
+  non-dynamic simple record
 
 ## v0.0.3 - 2023-01-24 - Support the root
 

--- a/octodns_ns1/__init__.py
+++ b/octodns_ns1/__init__.py
@@ -18,7 +18,7 @@ from octodns.provider.base import BaseProvider
 from octodns.record import Record, Update
 from octodns.record.geo_data import geo_data
 
-__VERSION__ = '0.0.3'
+__VERSION__ = '0.0.4'
 
 
 def _ensure_endswith_dot(string):


### PR DESCRIPTION
## v0.0.4 - 2023-03-31 - More (accurately) Dynamic

* Dynamic records filter chain ordering reworked to place country filters before
  regions, see https://github.com/octodns/octodns-ns1/pull/37 for
  details/discussion.
* AS implemented as a list of countries rather than the ASIAPAC region which
  didn't match as the AS list of countries in the first place
* AS, NA, and OC source their list of countries from octodns.record.geo_data
  rather than manually duplicating the information here.
* Add TL to the list of special case countries so that it can be individually
  targeted
* Fix for rule ordering when there's > 10 rules
* Fixed persistent change issue with dynamic records after the API started
  returning new fields under `config`

/cc @istr @viranch going to let this one sit for a bit since there's some fairly meaningful fixes/changes. 