### PR TITLE
Make sure geo is truthy, not just present

### DIFF
--- a/octodns_ns1/__init__.py
+++ b/octodns_ns1/__init__.py
@@ -1444,7 +1444,7 @@ class Ns1Provider(BaseProvider):
     def _params_for_A(self, record):
         if getattr(record, 'dynamic', False):
             return self._params_for_dynamic(record)
-        elif hasattr(record, 'geo'):
+        elif getattr(record, 'geo', False):
             return self._params_for_geo_A(record)
 
         return {'answers': record.values, 'ttl': record.ttl}, None

--- a/tests/test_provider_ns1.py
+++ b/tests/test_provider_ns1.py
@@ -516,12 +516,7 @@ class TestNs1Provider(TestCase):
         record_create_mock.assert_has_calls(
             [
                 call(
-                    'unit.tests',
-                    'unit.tests',
-                    'A',
-                    answers=[{'answer': ['1.2.3.4'], 'meta': {}}],
-                    filters=[],
-                    ttl=32,
+                    'unit.tests', 'unit.tests', 'A', answers=['1.2.3.4'], ttl=32
                 ),
                 call(
                     'unit.tests',
@@ -632,20 +627,10 @@ class TestNs1Provider(TestCase):
         record_update_mock.assert_has_calls(
             [
                 call(
-                    'unit.tests',
-                    'unit.tests',
-                    'A',
-                    answers=[{'answer': ['1.2.3.4'], 'meta': {}}],
-                    filters=[],
-                    ttl=32,
+                    'unit.tests', 'unit.tests', 'A', answers=['1.2.3.4'], ttl=32
                 ),
                 call(
-                    'unit.tests',
-                    'unit.tests',
-                    'A',
-                    answers=[{'answer': ['1.2.3.4'], 'meta': {}}],
-                    filters=[],
-                    ttl=32,
+                    'unit.tests', 'unit.tests', 'A', answers=['1.2.3.4'], ttl=32
                 ),
                 call(
                     'unit.tests',


### PR DESCRIPTION

`_params_for_A` was mistakenly looking for only the presence of `.geo` and its truthiness. It'll always be present on `A` and `AAAA` records, but only truthy when `geo` functionality is used. It just so happens that `_params_for_geo_A` returned valid params for the case when there were no geos so things worked. That said it returned extra information and was confusing and not the intended/expected flow.

This fixes that issue and checks that `geo` is present and truthy before using that path.

This was found while digging into hiccups in https://github.com/octodns/octodns-ns1/pull/45. The test side of things will change slightly back towards what I'm removing here, but that's fine and it's cleaner to fix things standalone in main before that change lands. 

/cc https://github.com/octodns/octodns-ns1/pull/45#discussion_r1157730933 @viranch 