### PR TITLE
Use native HTTP monitors for HTTP(S) healthchecks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 ## v0.0.5 - 2023-??-?? - ???
 
-* Switch to using actual HTTP monitors instead of emulating them in TCP monitors.
-  This effectively drops support for `http_version` configuration because HTTP
-  monitors use HTTP/1.1 only.
+* Allow using actual HTTP monitors instead of emulating them in TCP monitors.
+  Doing this is not forward-compatible, ie octodns-ns1 cannot be downgraded to
+  a previous version that doesn't support modern HTTP monitors. It also doesn't
+  honor the `http_version` configuration because these monitors can only talk
+  HTTP/1.1.
 
 ## v0.0.4 - 2023-04-06 - More (accurately) Dynamic
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.0.5 - 2023-??-?? - ???
+
+* Switch to using actual HTTP monitors instead of emulating them in TCP monitors.
+  This effectively drops support for `http_version` configuration because HTTP
+  monitors use HTTP/1.1 only.
+
 ## v0.0.4 - 2023-04-06 - More (accurately) Dynamic
 
 * Dynamic records filter chain ordering reworked to place country filters before

--- a/README.md
+++ b/README.md
@@ -61,10 +61,6 @@ providers:
         endpoint: my.nsone.endpoint # Default: api.nsone.net
         ignore-ssl-errors: true     # Default: false
         follow_pagination: false    # Default: true
-    # Optional. Default: HTTP/1.0 . Default HTTP protocol to use when 
-    # health-checking dynamic record endpoints. See "Health Check Options" 
-    # README section below to override per dynamic record.
-    default_healthcheck_http_version: HTTP/1.0
 
 ```
 
@@ -93,7 +89,6 @@ See https://github.com/octodns/octodns/blob/master/docs/dynamic_records.md#healt
 | connect_timeout | Timeout (in seconds) before we give up trying to connect | 2 |
 | response_timeout | Timeout (in seconds) after connecting to wait for output | 10 |
 | rapid_recheck | Enable or disable a second, automatic verification test before changing the status of a host. Enabling this option can help prevent false positives. | False |
-| http_version | Specify HTTP version to use when HTTP health-checking  a host. One of <ol><li>`HTTP/1.0`</li><li>`HTTP/1.1`</li><ol> | `HTTP/1.0` |
 
 ```yaml
 ---
@@ -105,7 +100,6 @@ See https://github.com/octodns/octodns/blob/master/docs/dynamic_records.md#healt
         connect_timeout: 2
         response_timeout: 10
         rapid_recheck: True
-        http_version: HTTP/1.1
 ```
 
 ### Development

--- a/README.md
+++ b/README.md
@@ -61,6 +61,15 @@ providers:
         endpoint: my.nsone.endpoint # Default: api.nsone.net
         ignore-ssl-errors: true     # Default: false
         follow_pagination: false    # Default: true
+    # Optional. Default: false. Use modern HTTP monitor (true) or the legacy
+    # HTTP-emulating TCP monitor (false) for HTTP(s) healthchecks.
+    use_http_monitors: false
+    # Optional. Default: HTTP/1.0. Default HTTP protocol to use when
+    # health-checking dynamic record endpoints. See "Health Check Options"
+    # README section below to override per dynamic record.
+    # This is only supported when use_http_monitors is set to false. If it
+    # is set to true, HTTP/1.1 will be used and it cannot be changed.
+    default_healthcheck_http_version: HTTP/1.0
 
 ```
 
@@ -89,6 +98,7 @@ See https://github.com/octodns/octodns/blob/master/docs/dynamic_records.md#healt
 | connect_timeout | Timeout (in seconds) before we give up trying to connect | 2 |
 | response_timeout | Timeout (in seconds) after connecting to wait for output | 10 |
 | rapid_recheck | Enable or disable a second, automatic verification test before changing the status of a host. Enabling this option can help prevent false positives. | False |
+| http_version | Specify HTTP version to use when HTTP health-checking a host. Only applicable if `use_http_monitors=False`. One of <ol><li>`HTTP/1.0`</li><li>`HTTP/1.1`</li><ol> | `HTTP/1.0` |
 
 ```yaml
 ---
@@ -100,6 +110,7 @@ See https://github.com/octodns/octodns/blob/master/docs/dynamic_records.md#healt
         connect_timeout: 2
         response_timeout: 10
         rapid_recheck: True
+        http_version: HTTP/1.1
 ```
 
 ### Development

--- a/octodns_ns1/__init__.py
+++ b/octodns_ns1/__init__.py
@@ -1102,9 +1102,7 @@ class Ns1Provider(BaseProvider):
         else:
             ret['job_type'] = 'http'
             proto = record.healthcheck_protocol.lower()
-            domain = value
-            if _type == 'AAAA':
-                domain = f'[{domain}]'
+            domain = f'[{value}]' if _type == 'AAAA' else value
             port = record.healthcheck_port
             path = record.healthcheck_path
             ret['config'] = {

--- a/octodns_ns1/__init__.py
+++ b/octodns_ns1/__init__.py
@@ -1619,16 +1619,34 @@ class Ns1Provider(BaseProvider):
 
                     have = existing.get(value)
                     if not have:
-                        self.log.info(
-                            '_extra_changes: missing monitor %s', name
-                        )
+                        if self.use_http_monitors:
+                            self.log.warning(
+                                '_extra_changes: missing monitor %s will be created of type http, '
+                                'this will not be forward-compatible and octodns-ns1 cannot be downgraded',
+                                name,
+                            )
+                        else:
+                            self.log.info(
+                                '_extra_changes: missing monitor %s', name
+                            )
                         update = True
                         continue
 
                     if not self._monitor_is_match(expected, have):
-                        self.log.info(
-                            '_extra_changes: monitor mis-match for %s', name
-                        )
+                        if expected['job_type'] != have['job_type']:
+                            self.log.warning(
+                                '_extra_changes: existing %s monitor %s will be deleted and replaced by a new %s monitor, '
+                                '%s will be temporarily treated as being healthy as a result '
+                                'and this is operation will be irreversible and not forward-compatible',
+                                have['job_type'],
+                                name,
+                                expected['job_type'],
+                                value,
+                            )
+                        else:
+                            self.log.info(
+                                '_extra_changes: monitor mis-match for %s', name
+                            )
                         update = True
 
                     if not have.get('notify_list'):

--- a/octodns_ns1/__init__.py
+++ b/octodns_ns1/__init__.py
@@ -1199,7 +1199,7 @@ class Ns1Provider(BaseProvider):
                 have_config = have.get(k, {})
                 for k, v in v.items():
                     if have_config.get(k, '--missing--') != v:
-                        self.log.info(
+                        self.log.debug(
                             f'{log_prefix}: got config.{k}={have_config.get(k)}, expected {v}'
                         )
                         return False
@@ -1621,7 +1621,7 @@ class Ns1Provider(BaseProvider):
                     if not have:
                         if self.use_http_monitors:
                             self.log.warning(
-                                '_extra_changes: missing monitor %s will be created of type http, '
+                                '_extra_changes: missing monitor "%s" will be created of type http, '
                                 'octodns-ns1 cannot be downgraded below v0.0.5 after applying this change',
                                 name,
                             )
@@ -1641,8 +1641,8 @@ class Ns1Provider(BaseProvider):
                             # NS1 monitor job types cannot be changed, so we need to do
                             # delete+create, which has a few implications:
                             self.log.warning(
-                                '_extra_changes: existing %s monitor %s will be deleted and replaced by a new %s monitor, '
-                                '%s will be temporarily treated as being healthy as a result, '
+                                '_extra_changes: existing %s monitor "%s" will be deleted and replaced by a new %s monitor, '
+                                '`%s` will be temporarily treated as being healthy as a result, '
                                 'this is operation will be irreversible and not forward-compatible, ie '
                                 'octodns-ns1 cannot be downgraded below v0.0.5 after applying this change',
                                 have['job_type'],

--- a/octodns_ns1/__init__.py
+++ b/octodns_ns1/__init__.py
@@ -430,8 +430,8 @@ class Ns1Provider(BaseProvider):
         self.log = getLogger(f'Ns1Provider[{id}]')
         self.log.debug(
             '__init__: id=%s, api_key=***, retry_count=%d, '
-            'monitor_regions=%s, parallelism=%s, client_config=%s',
-            'shared_notifylist=%s, use_http_monitors=%s',
+            'monitor_regions=%s, parallelism=%s, client_config=%s, '
+            'shared_notifylist=%s, use_http_monitors=%s, '
             'default_healthcheck_http_version=%s',
             id,
             retry_count,

--- a/octodns_ns1/__init__.py
+++ b/octodns_ns1/__init__.py
@@ -1633,7 +1633,13 @@ class Ns1Provider(BaseProvider):
                         continue
 
                     if not self._monitor_is_match(expected, have):
-                        if expected['job_type'] != have['job_type']:
+                        if expected['job_type'] == have['job_type']:
+                            self.log.info(
+                                '_extra_changes: monitor mis-match for %s', name
+                            )
+                        else:
+                            # NS1 monitor job types cannot be changed, so we need to do
+                            # delete+create, which has a few implications:
                             self.log.warning(
                                 '_extra_changes: existing %s monitor %s will be deleted and replaced by a new %s monitor, '
                                 '%s will be temporarily treated as being healthy as a result '
@@ -1642,10 +1648,6 @@ class Ns1Provider(BaseProvider):
                                 name,
                                 expected['job_type'],
                                 value,
-                            )
-                        else:
-                            self.log.info(
-                                '_extra_changes: monitor mis-match for %s', name
                             )
                         update = True
 

--- a/octodns_ns1/__init__.py
+++ b/octodns_ns1/__init__.py
@@ -1622,7 +1622,7 @@ class Ns1Provider(BaseProvider):
                         if self.use_http_monitors:
                             self.log.warning(
                                 '_extra_changes: missing monitor %s will be created of type http, '
-                                'this will not be forward-compatible and octodns-ns1 cannot be downgraded',
+                                'octodns-ns1 cannot be downgraded below v0.0.5 after applying this change',
                                 name,
                             )
                         else:
@@ -1642,8 +1642,9 @@ class Ns1Provider(BaseProvider):
                             # delete+create, which has a few implications:
                             self.log.warning(
                                 '_extra_changes: existing %s monitor %s will be deleted and replaced by a new %s monitor, '
-                                '%s will be temporarily treated as being healthy as a result '
-                                'and this is operation will be irreversible and not forward-compatible',
+                                '%s will be temporarily treated as being healthy as a result, '
+                                'this is operation will be irreversible and not forward-compatible, ie '
+                                'octodns-ns1 cannot be downgraded below v0.0.5 after applying this change',
                                 have['job_type'],
                                 name,
                                 expected['job_type'],


### PR DESCRIPTION
Ran into a show stopper problem with TCP monitors: NS1 errors out if the health-check path contains `&`, usually shows up when using query params. Root cause unknown, but HTTP monitors don't seem to have that problem.

Plus using HTTP monitors is the more appropriate way of implementing HTTP(s) healthchecks anyway.

This change will cause sync to trigger a (graceful) update for all dynamic records that use HTTP healthchecks.