### PR TITLE
Order of monitor regions shouldn't matter

### DIFF
--- a/tests/test_provider_ns1.py
+++ b/tests/test_provider_ns1.py
@@ -1160,6 +1160,18 @@ class TestNs1ProviderDynamic(TestCase):
             )
         )
 
+        # missing regions causes mismatch
+        self.assertFalse(
+            provider._monitor_is_match({'regions': ['lga', 'sin']}, {})
+        )
+
+        # out of order regions doesn't cause mismatch
+        self.assertTrue(
+            provider._monitor_is_match(
+                {'regions': ['lga', 'sin']}, {'regions': ['sin', 'lga']}
+            )
+        )
+
     @patch('octodns_ns1.Ns1Provider._feed_create')
     @patch('octodns_ns1.Ns1Client.monitors_update')
     @patch('octodns_ns1.Ns1Provider._monitor_create')


### PR DESCRIPTION
NS1 is returning monitor regions in arbitrary order, causing persistent sync on every run. This PR normalizes the order before comparison.