### PR TITLE
Detect missing monitors, log all planned changes

### DIFF
--- a/octodns_ns1/__init__.py
+++ b/octodns_ns1/__init__.py
@@ -1536,7 +1536,7 @@ class Ns1Provider(BaseProvider):
                 # Already changed, or no dynamic , no need to check it
                 continue
 
-            touched = False
+            update = False
 
             # Filter normalization
             # Check if filters for existing domains need an update
@@ -1553,8 +1553,7 @@ class Ns1Provider(BaseProvider):
                     'will update record',
                     domain,
                 )
-                extra.append(Update(record, record))
-                touched = True
+                update = True
 
             # check if any monitor needs to be synced
             existing = self._monitors_for(record)
@@ -1573,18 +1572,14 @@ class Ns1Provider(BaseProvider):
                         self.log.info(
                             '_extra_changes: missing monitor %s', name
                         )
-                        if not touched:
-                            extra.append(Update(record, record))
-                            touched = True
+                        update = True
                         continue
 
                     if not self._monitor_is_match(expected, have):
                         self.log.info(
                             '_extra_changes: monitor mis-match for %s', name
                         )
-                        if not touched:
-                            extra.append(Update(record, record))
-                            touched = True
+                        update = True
 
                     if not have.get('notify_list'):
                         self.log.info(
@@ -1592,9 +1587,10 @@ class Ns1Provider(BaseProvider):
                             name,
                             have['id'],
                         )
-                        if not touched:
-                            extra.append(Update(record, record))
-                            touched = True
+                        update = True
+
+            if update:
+                extra.append(Update(record, record))
 
         return extra
 

--- a/octodns_ns1/__init__.py
+++ b/octodns_ns1/__init__.py
@@ -1533,7 +1533,7 @@ class Ns1Provider(BaseProvider):
         extra = []
         for record in desired.records:
             if not getattr(record, 'dynamic', False):
-                # Already changed, or no dynamic , no need to check it
+                # no need to check non-dynamic simple records
                 continue
 
             update = False

--- a/octodns_ns1/__init__.py
+++ b/octodns_ns1/__init__.py
@@ -1532,7 +1532,7 @@ class Ns1Provider(BaseProvider):
         changed = set([c.record for c in changes])
         extra = []
         for record in desired.records:
-            if record in changed or not getattr(record, 'dynamic', False):
+            if not getattr(record, 'dynamic', False):
                 # Already changed, or no dynamic , no need to check it
                 continue
 
@@ -1589,7 +1589,7 @@ class Ns1Provider(BaseProvider):
                         )
                         update = True
 
-            if update:
+            if update and record not in changed:
                 extra.append(Update(record, record))
 
         return extra

--- a/tests/test_provider_ns1.py
+++ b/tests/test_provider_ns1.py
@@ -2305,9 +2305,9 @@ class TestNs1ProviderDynamic(TestCase):
 
         # If it's in the changed list, it'll be ignored
         reset()
+        monitors_for_mock.side_effect = [{}]
         extra = provider._extra_changes(desired, [update])
         self.assertFalse(extra)
-        monitors_for_mock.assert_not_called()
 
         # Missing monitor should trigger an update
         reset()

--- a/tests/test_provider_ns1.py
+++ b/tests/test_provider_ns1.py
@@ -2288,11 +2288,13 @@ class TestNs1ProviderDynamic(TestCase):
         self.assertIsInstance(extra, Update)
         self.assertEqual(dynamic, extra.new)
         monitors_for_mock.assert_has_calls([call(dynamic)])
-        gend['notify_list'] = 'xyz'
 
-        # Change the healthcheck protocol and we'll expect to see an update
+        # Add notify_list back and change the healthcheck protocol, we'll still
+        # expect to see an update
         reset()
+        gend['notify_list'] = 'xyz'
         dynamic._octodns['healthcheck']['protocol'] = 'HTTPS'
+        del gend['notify_list']
         monitors_for_mock.side_effect = [{'1.2.3.4': gend}]
         extra = provider._extra_changes(desired, [])
         self.assertEqual(1, len(extra))
@@ -2300,7 +2302,6 @@ class TestNs1ProviderDynamic(TestCase):
         self.assertIsInstance(extra, Update)
         self.assertEqual(dynamic, extra.new)
         monitors_for_mock.assert_has_calls([call(dynamic)])
-        dynamic._octodns['healthcheck']['protocol'] = 'HTTP'
 
         # If it's in the changed list, it'll be ignored
         reset()
@@ -2308,7 +2309,7 @@ class TestNs1ProviderDynamic(TestCase):
         self.assertFalse(extra)
         monitors_for_mock.assert_not_called()
 
-        # Missing monitor
+        # Missing monitor should trigger an update
         reset()
         monitors_for_mock.side_effect = [{}]
         extra = provider._extra_changes(desired, [])
@@ -2320,11 +2321,8 @@ class TestNs1ProviderDynamic(TestCase):
         monitors_for_mock.side_effect = [{}]
         extra = provider._extra_changes(desired, [])
         self.assertFalse(extra)
-        dynamic.dynamic.pools['iad'].data['values'][0]['status'] = 'obey'
 
         # Test changes in filters
-        # skip monitor checks for filter tests
-        dynamic.dynamic.pools['iad'].data['values'][0]['status'] = 'up'
 
         # No change in filters
         reset()
@@ -2397,36 +2395,6 @@ class TestNs1ProviderDynamic(TestCase):
         monitors_for_mock.side_effect = [{}]
         extra = provider._extra_changes(desired, [])
         self.assertTrue(extra)
-        ns1_zone['records'][0]['filters'][0]['disabled'] = False
-
-        # invalid filters and missing monitor doesn't produce duplicate changes
-        reset()
-        ns1_zone['records'][0]['filters'][0]['disabled'] = True
-        dynamic.dynamic.pools['iad'].data['values'][0]['status'] = 'obey'
-        monitors_for_mock.side_effect = [{}]
-        extra = provider._extra_changes(desired, [])
-        self.assertEqual(1, len(extra))
-        ns1_zone['records'][0]['filters'][0]['disabled'] = False
-
-        # invalid filters and out-of-sync monitor doesn't produce duplicate changes
-        reset()
-        ns1_zone['records'][0]['filters'][0]['disabled'] = True
-        dynamic._octodns['healthcheck']['protocol'] = 'HTTPS'
-        monitors_for_mock.side_effect = [{'1.2.3.4': gend}]
-        extra = provider._extra_changes(desired, [])
-        self.assertEqual(1, len(extra))
-        ns1_zone['records'][0]['filters'][0]['disabled'] = False
-        dynamic._octodns['healthcheck']['protocol'] = 'HTTP'
-
-        # out-of-sync monitor and without notify_list doesn't produce duplicate changes
-        reset()
-        dynamic._octodns['healthcheck']['protocol'] = 'HTTPS'
-        del gend['notify_list']
-        monitors_for_mock.side_effect = [{'1.2.3.4': gend}]
-        extra = provider._extra_changes(desired, [])
-        self.assertEqual(1, len(extra))
-        dynamic._octodns['healthcheck']['protocol'] = 'HTTP'
-        gend['notify_list'] = 'xyz'
 
     DESIRED = Zone('unit.tests.', [])
 


### PR DESCRIPTION
Monitors deleted or unlinked from the portal are not detected today. This PR handles that.

It also logs all the things detected out of sync by _extra_changes rather than exiting on detecting any one change. This helps inform users of all changes that will be made.