### PR TITLE
Implement Provider.list_zones for dynamic zone config support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.0.6 - 2023-??-?? - ???
+
+* Adds Provider.list_zones to enable new dynamic zone config functionality
+
 ## v0.0.5 - 2023-07-27 - Dynamic Subnets
 
 * Allow using actual HTTP monitors instead of emulating them in TCP monitors.

--- a/octodns_ns1/__init__.py
+++ b/octodns_ns1/__init__.py
@@ -262,6 +262,10 @@ class Ns1Client(object):
             self._zones_cache[name] = self._try(self._zones.retrieve, name)
         return self._zones_cache[name]
 
+    def zones_list(self):
+        # TODO: explore caching all of these if they have sufficient details
+        return self._try(self._zones.list)
+
     def _try(self, method, *args, **kwargs):
         tries = self.retry_count
         while True:  # We'll raise to break after our tries expire
@@ -920,6 +924,9 @@ class Ns1Provider(BaseProvider):
                 }
             )
         return {'ttl': record['ttl'], 'type': _type, 'values': values}
+
+    def list_zones(self):
+        return sorted([f'{z["zone"]}.' for z in self._client.zones_list()])
 
     def populate(self, zone, target=False, lenient=False):
         self.log.debug(

--- a/tests/test_provider_ns1.py
+++ b/tests/test_provider_ns1.py
@@ -3259,3 +3259,16 @@ class TestNs1Client(TestCase):
         meta = {'country': ('PN', 'UM')}
         geos = provider._parse_rule_geos(meta, notes)
         self.assertEqual({'OC-PN', 'OC-UM'}, geos)
+
+    @patch('ns1.rest.zones.Zones.list')
+    def test_zones_list(self, mock):
+        data = [
+            {'a': 42, 'zone': 'other.net'},
+            {'other': 'stuff', 'zone': 'first.com'},
+        ]
+        mock.side_effect = [data, data]
+
+        provider = Ns1Provider('test', 'api-key')
+
+        self.assertEqual(data, provider._client.zones_list())
+        self.assertEqual(['first.com.', 'other.net.'], provider.list_zones())


### PR DESCRIPTION
Adds `Provider.list_zones` method to allow using `Ns1Provider` as a source of dynamic zone configs.

/cc https://github.com/octodns/octodns/pull/1026 for base functionality that will utilize this