### PR TITLE
Don't log.exception on 404s, noisy when zones are being created

### DIFF
--- a/octodns_ns1/__init__.py
+++ b/octodns_ns1/__init__.py
@@ -284,13 +284,14 @@ class Ns1Client(object):
                 sleep(period)
                 tries -= 1
             except ResourceException as e:
-                self.log.exception(
-                    "_try: method=%s, args=%s, response=%s, body=%s",
-                    method.__name__,
-                    str(args),
-                    e.response,
-                    e.body,
-                )
+                if not e.response or e.response.status_code != 404:
+                    self.log.exception(
+                        "_try: method=%s, args=%s, response=%s, body=%s",
+                        method.__name__,
+                        str(args),
+                        e.response,
+                        e.body,
+                    )
                 raise
 
 

--- a/tests/test_provider_ns1.py
+++ b/tests/test_provider_ns1.py
@@ -492,10 +492,13 @@ class TestNs1Provider(TestCase):
             provider.apply(plan)
         self.assertEqual(zone_create_mock.side_effect, ctx.exception)
 
-        # non-existent zone, create
+        # non-existent zone/404, create
+        class DummyResponse:
+            status_code = 404
+
         reset()
         zone_retrieve_mock.side_effect = ResourceException(
-            'server error: zone not found'
+            'server error: zone not found', response=DummyResponse(), body='x'
         )
 
         zone_create_mock.side_effect = ['foo']


### PR DESCRIPTION
In testing unrelated stuff locally I noticed that `ResourceException`s are thrown for 404s, i.e. when a zone doesn't exist and needs to be created. That makes for a really noisy and slightly scary log output for a normal use case. This code updates things so that 404s don't log.

/cc https://github.com/octodns/octodns-ns1/pull/71 @jdickson0296 