### PR TITLE
v0.0.7 version bump & changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.0.7 - 2023-11-14 - Maintenance release
+
+* Improved NS1 API error logging
+* Misc improvements to the CI setup, documentation and fix to the release
+  packaging metadata
+
 ## v0.0.6 - 2023-09-28 - Dynamic zones & bug fixes
 
 * Adds Provider.list_zones to enable new dynamic zone config functionality

--- a/octodns_ns1/__init__.py
+++ b/octodns_ns1/__init__.py
@@ -19,7 +19,7 @@ from octodns.record.geo import GeoCodes
 from octodns.record.geo_data import geo_data
 
 # TODO: remove __VERSION__ with the next major version release
-__version__ = __VERSION__ = '0.0.6'
+__version__ = __VERSION__ = '0.0.7'
 
 
 def _ensure_endswith_dot(string):


### PR DESCRIPTION
## v0.0.7 - 2023-11-14 - Maintenance release

* Improved NS1 API error logging
* Misc improvements to the CI setup, documentation and fix to the release
  packaging metadata
