### PR TITLE
Version 1.0.0 version bump & changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v1.0.0 - 2024-??-?? -
+## v1.0.0 - 2025-05-04 - Long overdue 1.?0
 
 ### Notedworthy Changes:
 

--- a/octodns_ns1/__init__.py
+++ b/octodns_ns1/__init__.py
@@ -19,7 +19,7 @@ from octodns.record.geo import GeoCodes
 from octodns.record.geo_data import geo_data
 
 # TODO: remove __VERSION__ with the next major version release
-__version__ = __VERSION__ = '0.0.7'
+__version__ = __VERSION__ = '1.0.0'
 
 
 def _ensure_endswith_dot(string):


### PR DESCRIPTION
## v1.0.0 - 2025-05-04 - Long overdue 1.?0

### Notedworthy Changes:

* `geo` record support removed, records should be migrated to `dynamic` before
  upgrading.
* `SPF` record support removed, records should be migrated to `TXT` before
  upgrading.
* DNAME, DS, and TLSA record type support added.

### Other Changes:

* Validate that healthcheck protocol is supported (HTTP, HTTPS, ICMP, TCP)
* Validate that continent is supported (Antarctica is supported by octoDNS but not by NS1)
* Address pending octoDNS 2.x deprecations, require minimum of 1.5.x