### PR TITLE
Fix handling of non-dynamic A/AAAA records with tier > 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.0.1 - 2025-05-?? -
+
+* Restore handling of tier > 1 advanced A/AAAA records that are not dynamic
+
 ## v1.0.0 - 2025-05-04 - Long overdue 1.?0
 
 ### Notedworthy Changes:

--- a/tests/test_provider_ns1.py
+++ b/tests/test_provider_ns1.py
@@ -2411,6 +2411,47 @@ class TestNs1ProviderDynamic(TestCase):
             data,
         )
 
+    def test_data_for_A_non_dynamic(self):
+        provider = Ns1Provider('test', 'api-key')
+
+        # empty note
+        ns1_record = {
+            'answers': [
+                {
+                    'answer': ['iad.unit.tests.'],
+                    'meta': {'priority': 1, 'weight': 12, 'note': '', 'up': {}},
+                    'region': None,
+                }
+            ],
+            'domain': 'foo.unit.tests',
+            'filters': None,
+            'regions': None,
+            'tier': 3,
+            'ttl': 43,
+            'type': 'A',
+        }
+        data = provider._data_for_A('A', ns1_record)
+        self.assertEqual({'ttl': 43, 'type': 'A', 'values': []}, data)
+
+        # no note
+        ns1_record = {
+            'answers': [
+                {
+                    'answer': ['iad.unit.tests.'],
+                    'meta': {'priority': 1, 'weight': 12, 'up': {}},
+                    'region': None,
+                }
+            ],
+            'domain': 'foo.unit.tests',
+            'filters': None,
+            'regions': None,
+            'tier': 3,
+            'ttl': 43,
+            'type': 'A',
+        }
+        data = provider._data_for_A('A', ns1_record)
+        self.assertEqual({'ttl': 43, 'type': 'A', 'values': []}, data)
+
     def test_data_for_dynamic_CNAME(self):
         provider = Ns1Provider('test', 'api-key')
 


### PR DESCRIPTION
Removal of `geo` support went too far and took out some checks for non-dynamic `A`/`AAAA` records. This puts them back. 

Tests still required.

/cc https://github.com/octodns/octodns-ns1/commit/478d82bd5bd6de79d440f834e5693270fef8ab40#r156480474 @mtgagnon