### PR TITLE
Version 1.0.1 version bump & changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v1.0.1 - 2025-05-?? -
+## v1.0.1 - 2025-05-07 - Fix the edges
 
 * Restore handling of tier > 1 advanced A/AAAA records that are not dynamic
 

--- a/octodns_ns1/__init__.py
+++ b/octodns_ns1/__init__.py
@@ -19,7 +19,7 @@ from octodns.record.geo import GeoCodes
 from octodns.record.geo_data import geo_data
 
 # TODO: remove __VERSION__ with the next major version release
-__version__ = __VERSION__ = '1.0.0'
+__version__ = __VERSION__ = '1.0.1'
 
 
 def _ensure_endswith_dot(string):


### PR DESCRIPTION
## v1.0.1 - 2025-05-07 - Fix the edges

* Restore handling of tier > 1 advanced A/AAAA records that are not dynamic