### PR TITLE
make sure we handle TXT/SPF records with no short answers

### DIFF
--- a/.changelog/4c3c775e9fd343089403d6071d8d0bfd.md
+++ b/.changelog/4c3c775e9fd343089403d6071d8d0bfd.md
@@ -1,4 +1,0 @@
----
-type: patch
----
-Handle TXT records with no values

--- a/.changelog/4c3c775e9fd343089403d6071d8d0bfd.md
+++ b/.changelog/4c3c775e9fd343089403d6071d8d0bfd.md
@@ -1,0 +1,4 @@
+---
+type: patch
+---
+Handle TXT records with no values

--- a/.changelog/c21ee7ef4f6546ee813441d051777436.md
+++ b/.changelog/c21ee7ef4f6546ee813441d051777436.md
@@ -1,0 +1,4 @@
+---
+type: patch
+---
+change-description fixed bug where filterchain TXT record had no short_answers variable, causing a crash in _data_for_SPF

--- a/octodns_ns1/__init__.py
+++ b/octodns_ns1/__init__.py
@@ -789,7 +789,12 @@ class Ns1Provider(BaseProvider):
     _data_for_AAAA = _data_for_A
 
     def _data_for_SPF(self, _type, record):
-        values = [v.replace(';', '\\;') for v in record['short_answers']]
+        try:
+            values = [v.replace(';', '\\;') for v in record['short_answers']]
+        except KeyError:
+            # some TXT records don't have short_answers, (filterchain records have no answers)
+            values = []
+
         return {'ttl': record['ttl'], 'type': _type, 'values': values}
 
     _data_for_TXT = _data_for_SPF

--- a/tests/test_provider_ns1.py
+++ b/tests/test_provider_ns1.py
@@ -658,6 +658,9 @@ class TestNs1Provider(TestCase):
             provider._data_for_TXT('TXT', record)['values'],
         )
 
+        record = {'ttl': 31}
+        self.assertEqual([], provider._data_for_TXT('TXT', record)['values'])
+
         record = {
             'ttl': 31,
             'short_answers': ['no', 'foo; bar baz; blip', 'yes'],


### PR DESCRIPTION
_data_for_SPF does not handle the case where 'short_answers' does not exist in the answer. This creates issues when we have TXT records that are filter chain records. This patch addresses this by adding a try catch, could also do an if/else checking for the key. 