### PR TITLE
Version 1.0.2 bump & changelog update

### DIFF
--- a/.changelog/05f3b5dc965240e7a07f71522e390fd9.md
+++ b/.changelog/05f3b5dc965240e7a07f71522e390fd9.md
@@ -1,4 +1,0 @@
----
-type: patch
----
-Use new [changelet](https://github.com/octodns/changelet) tooling

--- a/.changelog/0c766cb99c8a419aa8af6396b7ee56aa.md
+++ b/.changelog/0c766cb99c8a419aa8af6396b7ee56aa.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Run changelog check during pre-commit

--- a/.changelog/19ff75c45bf74a129a9e72ef9994bb3f.md
+++ b/.changelog/19ff75c45bf74a129a9e72ef9994bb3f.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/1f3bad21006d4e048be8cf8695f062da.md
+++ b/.changelog/1f3bad21006d4e048be8cf8695f062da.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/41bc3f8da3c84ca9a734d0be96c589c5.md
+++ b/.changelog/41bc3f8da3c84ca9a734d0be96c589c5.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update scripts to use common.sh

--- a/.changelog/47ce4e189ad24847a6d5d0ee871f0b87.md
+++ b/.changelog/47ce4e189ad24847a6d5d0ee871f0b87.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Pull in the latest template changes

--- a/.changelog/6ca165b644ab422a84ea8bdec5f3fd28.md
+++ b/.changelog/6ca165b644ab422a84ea8bdec5f3fd28.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements.txt

--- a/.changelog/7f722301e34140f7bbf0b4126709342d.md
+++ b/.changelog/7f722301e34140f7bbf0b4126709342d.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Add JSON coverage report format

--- a/.changelog/88d1ae50e5ec4685af7f603be736e4ef.md
+++ b/.changelog/88d1ae50e5ec4685af7f603be736e4ef.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/8d5ac9f8740a4cdd9dde916a17e8ffef.md
+++ b/.changelog/8d5ac9f8740a4cdd9dde916a17e8ffef.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Switch to proviso for requirements.txt management

--- a/.changelog/c21ee7ef4f6546ee813441d051777436.md
+++ b/.changelog/c21ee7ef4f6546ee813441d051777436.md
@@ -1,4 +1,0 @@
----
-type: patch
----
-change-description fixed bug where filterchain TXT record had no short_answers variable, causing a crash in _data_for_SPF

--- a/.changelog/c74010fce1924854861f370f8e9343ba.md
+++ b/.changelog/c74010fce1924854861f370f8e9343ba.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/e7947a73af284a1b9143737b77a7e05c.md
+++ b/.changelog/e7947a73af284a1b9143737b77a7e05c.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements*.txt

--- a/.changelog/f16b03971a3d4faeb8ac6559b9902ee8.md
+++ b/.changelog/f16b03971a3d4faeb8ac6559b9902ee8.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Use script/common.sh in script/update-requirements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.2 - 2026-04-03
+
+Patch:
+* change-description fixed bug where filterchain TXT record had no short_answers variable, causing a crash in _data_for_SPF - [#98](https://github.com/octodns/octodns-ns1/pull/98)
+* Use new [changelet](https://github.com/octodns/changelet) tooling - [#97](https://github.com/octodns/octodns-ns1/pull/97)
+
 ## v1.0.1 - 2025-05-07 - Fix the edges
 
 * Restore handling of tier > 1 advanced A/AAAA records that are not dynamic

--- a/octodns_ns1/__init__.py
+++ b/octodns_ns1/__init__.py
@@ -19,7 +19,7 @@ from octodns.record.geo import GeoCodes
 from octodns.record.geo_data import geo_data
 
 # TODO: remove __VERSION__ with the next major version release
-__version__ = __VERSION__ = '1.0.1'
+__version__ = __VERSION__ = '1.0.2'
 
 
 def _ensure_endswith_dot(string):


### PR DESCRIPTION
## 1.0.2 - 2026-04-03

Patch:
* change-description fixed bug where filterchain TXT record had no short_answers variable, causing a crash in _data_for_SPF - [#98](https://github.com/octodns/octodns-ns1/pull/98)
* Use new [changelet](https://github.com/octodns/changelet) tooling - [#97](https://github.com/octodns/octodns-ns1/pull/97)

